### PR TITLE
fix(): android make file edits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "coins-bip32"
 version = "0.6.0"
-source = "git+ssh://git@github.com/Uniswap/bitcoin-rs#ded4619e238243e1c55d79fc916f17505bea58d9"
+source = "git+ssh://git@github.com/Uniswap/bitcoin-rs.git#ded4619e238243e1c55d79fc916f17505bea58d9"
 dependencies = [
  "bincode",
  "bs58",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ hex = "0.4.3"
 bytes = "1.1.0"
 
 [patch.crates-io]
-coins-bip32 = { git = 'ssh://git@github.com/Uniswap/bitcoin-rs' }
+coins-bip32 = { git = 'ssh://git@github.com/Uniswap/bitcoin-rs.git' }
 
 # profile for the wasm example
 [profile.release.package.ethers-wasm]

--- a/ethers-ffi/Cargo.toml
+++ b/ethers-ffi/Cargo.toml
@@ -14,7 +14,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lib]
-crate-type = ["lib", "staticlib"]
+crate-type = ["staticlib", "cdylib"] # iOS uses staticlib, Android uses cdylib
 name = "ethers_ffi"
 
 [dependencies]
@@ -32,4 +32,4 @@ hex = { version = "0.4.3", default-features = false }
 
 [dev-dependencies]
 cargo-lipo = ">=3.2.0"
-cbindgen = "0.24.3" 
+cbindgen = "0.24.3"

--- a/ethers-ffi/Makefile
+++ b/ethers-ffi/Makefile
@@ -4,18 +4,18 @@ NAME = libethers_ffi
 LIB = $(NAME).a
 SO = $(NAME).so
 ARCHS_IOS = x86_64-apple-ios aarch64-apple-ios
-ARCHS_ANDROID = aarch64-linux-android armv7-linux-androideabi arm-linux-androideabi i686-linux-android x86_64-linux-android
-NDK_STANDALONE = ./NDK
-ANDROID_DEST = ./react-native/android/app/src/main/jniLibs
+ARCHS_ANDROID = aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+NDK_STANDALONE = ~/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64
+ANDROID_DEST = ./ethers-rs-mobile/android/jniLibs
 IOS_DEST = ./ethers-rs-mobile/ios
-CARGO_PARAMS = --no-default-features
+CARGO_PARAMS = --no-default-features 
 
 TARGET_DIR = ../target
 
 all: android ios
 
 android-setup:
-	rustup target add aarch64-linux-android armv7-linux-androideabi arm-linux-androideabi i686-linux-android x86_64-linux-android
+	rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
 
 android-build: $(ARCHS_ANDROID)
 
@@ -40,37 +40,31 @@ android: android-setup android-build
 	cp $(TARGET_DIR)/i686-linux-android/release/$(SO) ${ANDROID_DEST}/x86/$(SO)
 	cp $(TARGET_DIR)/x86_64-linux-android/release/$(SO) ${ANDROID_DEST}/x86_64/$(SO)
 	cp $(TARGET_DIR)/aarch64-linux-android/release/$(SO) ${ANDROID_DEST}/arm64-v8a/$(SO)
-	cp $(TARGET_DIR)/arm-linux-androideabi/release/$(SO) ${ANDROID_DEST}/armeabi/$(SO)
+
 	cp $(TARGET_DIR)/armv7-linux-androideabi/release/$(SO) ${ANDROID_DEST}/armeabi-v7a/$(SO)
 
 aarch64-linux-android:
 	PATH=$(PATH):$(NDK_STANDALONE)/arm64/bin \
-	CC=$@-gcc \
-	CXX=$@-g++ \
-	cargo build $(CARGO_PARAMS) --target $@ --release --lib
-
-arm-linux-androideabi:
-	PATH=$(PATH):$(NDK_STANDALONE)/arm/bin \
-	CC=$@-gcc \
-	CXX=$@-g++ \
+	CC=$@-clang \
+	CXX=$@-clang++ \
 	cargo build $(CARGO_PARAMS) --target $@ --release --lib
 
 armv7-linux-androideabi:
 	PATH=$(PATH):$(NDK_STANDALONE)/arm/bin \
-	CC=arm-linux-androideabi-gcc \
-	CXX=arm-linux-androideabi-g++ \
+	CC=armv7a-linux-androideabi-gcc \
+	CXX=armv7a-linux-androideabi-g++ \
 	cargo build $(CARGO_PARAMS) --target $@ --release --lib
 
 i686-linux-android:
 	PATH=$(PATH):$(NDK_STANDALONE)/x86/bin \
-	CC=$@-gcc \
-	CXX=$@-g++ \
+	CC=$@-clang \
+	CXX=$@-clang++ \
 	cargo build $(CARGO_PARAMS) --target $@ --release --lib
 
 x86_64-linux-android:
 	PATH=$(PATH):$(NDK_STANDALONE)/x86_64/bin \
-	CC=$@-gcc \
-	CXX=$@-g++ \
+	CC=$@-clang \
+	CXX=$@-clang++ \
 	cargo build $(CARGO_PARAMS) --target $@ --release --lib
 
 .PHONY: $(ARCHS_IOS)


### PR DESCRIPTION
1. Updates format for repository link to include `.git`
2. Adds proper dynamic library support for Android in crates.
3. Removes android architecture target that seems unnecessary and problematic. 
- Unsure if we should update this c compiler to `clang` or not. It was a fix for mac and this repo seems geared towards Linux. Technically `gcc` as the c compiler should still use `clang` on Mac, but this setup can get a bit tricky. 