### PR TITLE
build: Use xcframework in ethers_ffi to support arm64 simulators

### DIFF
--- a/ethers-ffi/Makefile
+++ b/ethers-ffi/Makefile
@@ -3,12 +3,17 @@
 NAME = libethers_ffi
 LIB = $(NAME).a
 SO = $(NAME).so
-ARCHS_IOS = x86_64-apple-ios aarch64-apple-ios aarch64-apple-ios-sim
 ARCHS_ANDROID = aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
 NDK_STANDALONE = ~/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64
 ANDROID_DEST = ./ethers-rs-mobile/android/jniLibs
 IOS_DEST = ./ethers-rs-mobile/ios
 CARGO_PARAMS = --no-default-features 
+
+ARCHS_IOS = aarch64-apple-ios
+ARCHS_IOS_SIM = x86_64-apple-ios aarch64-apple-ios-sim
+IOS_LIB = $(NAME).xcframework
+XCFRAMEWORK = $(NAME)-iOS.xcframework
+IOS_PLATFORMS = iphoneos iphonesimulator
 
 TARGET_DIR = ../target
 
@@ -19,10 +24,7 @@ android-setup:
 
 android-build: $(ARCHS_ANDROID)
 
-ios-setup: 
-	rustup target add $(ARCHS_IOS)
-
-ios: ios-setup $(LIB)
+ios: $(IOS_LIB)
 
 clean:
 	rm -rf $(IOS_DEST)
@@ -40,7 +42,6 @@ android: android-setup android-build
 	cp $(TARGET_DIR)/i686-linux-android/release/$(SO) ${ANDROID_DEST}/x86/$(SO)
 	cp $(TARGET_DIR)/x86_64-linux-android/release/$(SO) ${ANDROID_DEST}/x86_64/$(SO)
 	cp $(TARGET_DIR)/aarch64-linux-android/release/$(SO) ${ANDROID_DEST}/arm64-v8a/$(SO)
-
 	cp $(TARGET_DIR)/armv7-linux-androideabi/release/$(SO) ${ANDROID_DEST}/armeabi-v7a/$(SO)
 
 aarch64-linux-android:
@@ -67,11 +68,19 @@ x86_64-linux-android:
 	CXX=$@-clang++ \
 	cargo build $(CARGO_PARAMS) --target $@ --release --lib
 
-.PHONY: $(ARCHS_IOS)
-$(ARCHS_IOS): %:
+iphoneos: $(ARCHS_IOS)
+	mkdir -p $(TARGET_DIR)/$@
+	lipo -create -output $(TARGET_DIR)/$@/$(LIB) $(foreach arch,$(ARCHS_IOS),$(wildcard $(TARGET_DIR)/$(arch)/release/$(LIB)))
+
+iphonesimulator: $(ARCHS_IOS_SIM)
+	mkdir -p $(TARGET_DIR)/$@
+	lipo -create -output $(TARGET_DIR)/$@/$(LIB) $(foreach arch,$(ARCHS_IOS_SIM),$(wildcard $(TARGET_DIR)/$(arch)/release/$(LIB)))
+
+.PHONY: $(ARCHS_IOS) $(ARCHS_IOS_SIM)
+$(ARCHS_IOS) $(ARCHS_IOS_SIM): %:
 	cargo build $(CARGO_PARAMS) --target $@ --release --lib
 
-$(LIB): $(ARCHS_IOS)
+$(IOS_LIB): $(IOS_PLATFORMS)
 	mkdir -p $(IOS_DEST)
-	lipo -create -output $(IOS_DEST)/$@ $(foreach arch,$(ARCHS_IOS),$(wildcard $(TARGET_DIR)/$(arch)/release/$(LIB)))
-	cbindgen --config cbindgen.toml --crate ethers-ffi --output $(IOS_DEST)/libethers_ffi.h 
+	cbindgen --config cbindgen.toml --crate ethers-ffi --output $(TARGET_DIR)/$(NAME).h
+	xcodebuild -create-xcframework -library $(TARGET_DIR)/iphoneos/$(LIB) -headers $(TARGET_DIR)/$(NAME).h -library $(TARGET_DIR)/iphonesimulator/$(LIB) -headers $(TARGET_DIR)/$(NAME).h -output $(IOS_DEST)/$@ 

--- a/ethers-ffi/Makefile
+++ b/ethers-ffi/Makefile
@@ -3,7 +3,7 @@
 NAME = libethers_ffi
 LIB = $(NAME).a
 SO = $(NAME).so
-ARCHS_IOS = x86_64-apple-ios aarch64-apple-ios
+ARCHS_IOS = x86_64-apple-ios aarch64-apple-ios aarch64-apple-ios-sim
 ARCHS_ANDROID = aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
 NDK_STANDALONE = ~/Library/Android/sdk/ndk/25.2.9519653/toolchains/llvm/prebuilt/darwin-x86_64
 ANDROID_DEST = ./ethers-rs-mobile/android/jniLibs

--- a/ethers-ffi/Makefile
+++ b/ethers-ffi/Makefile
@@ -11,8 +11,7 @@ CARGO_PARAMS = --no-default-features
 
 ARCHS_IOS = aarch64-apple-ios
 ARCHS_IOS_SIM = x86_64-apple-ios aarch64-apple-ios-sim
-IOS_LIB = $(NAME).xcframework
-XCFRAMEWORK = $(NAME)-iOS.xcframework
+IOS_LIB = EthersRS.xcframework
 IOS_PLATFORMS = iphoneos iphonesimulator
 
 TARGET_DIR = ../target
@@ -24,7 +23,10 @@ android-setup:
 
 android-build: $(ARCHS_ANDROID)
 
-ios: $(IOS_LIB)
+ios-setup: 
+	rustup target add $(ARCHS_IOS) $(ARCHS_IOS_SIM)
+
+ios: ios-setup $(IOS_LIB)
 
 clean:
 	rm -rf $(IOS_DEST)
@@ -82,5 +84,5 @@ $(ARCHS_IOS) $(ARCHS_IOS_SIM): %:
 
 $(IOS_LIB): $(IOS_PLATFORMS)
 	mkdir -p $(IOS_DEST)
-	cbindgen --config cbindgen.toml --crate ethers-ffi --output $(TARGET_DIR)/$(NAME).h
-	xcodebuild -create-xcframework -library $(TARGET_DIR)/iphoneos/$(LIB) -headers $(TARGET_DIR)/$(NAME).h -library $(TARGET_DIR)/iphonesimulator/$(LIB) -headers $(TARGET_DIR)/$(NAME).h -output $(IOS_DEST)/$@ 
+	cbindgen --config cbindgen.toml --crate ethers-ffi --output $(TARGET_DIR)/headers/$(NAME).h
+	xcodebuild -create-xcframework -library $(TARGET_DIR)/iphoneos/$(LIB) -headers $(TARGET_DIR)/headers -library $(TARGET_DIR)/iphonesimulator/$(LIB) -headers $(TARGET_DIR)/headers -output $(IOS_DEST)/$@ 

--- a/ethers-ffi/ethers-rs-mobile/EthersRS.podspec
+++ b/ethers-ffi/ethers-rs-mobile/EthersRS.podspec
@@ -15,7 +15,8 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => "9.0", :tvos => "11.0" }
   s.source       = { :git => "https://github.com/uniswap/ethers-rs-mobile.git", :tag => "#{s.version}" }
 
+  s.public_header_files = "ios/EthersRS.xcframework/Headers/*.h"
+  s.preserve_paths = "ios/EthersRS.xcframework/Headers/*.h"
   s.vendored_frameworks = "ios/EthersRS.xcframework"
-  s.xcconfig = { 'HEADER_SEARCH_PATHS' => "${PODS_XCFRAMEWORKS_BUILD_DIR}/ios/EthersRS.xcframework/Headers/**" }
-
+  s.xcconfig = { 'HEADER_SEARCH_PATHS' => "${PODS_ROOT}/#{s.name}/ios/**" }
 end

--- a/ethers-ffi/ethers-rs-mobile/EthersRS.podspec
+++ b/ethers-ffi/ethers-rs-mobile/EthersRS.podspec
@@ -15,10 +15,7 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => "9.0", :tvos => "11.0" }
   s.source       = { :git => "https://github.com/uniswap/ethers-rs-mobile.git", :tag => "#{s.version}" }
 
-  s.public_header_files = "libethers_ffi.xcframework/ios-arm64/Headers"
-  s.source_files = 'libethers_ffi.xcframework/ios-arm64/Headers'
-  s.preserve_paths =  'ios/libethers_ffi.xcframework/*'
-  s.vendored_frameworks = "ios/libethers_ffi.xcframework"
-  s.xcconfig = { 'HEADER_SEARCH_PATHS' => "${PODS_ROOT}/#{s.name}/ios/**" }
+  s.vendored_frameworks = "ios/EthersRS.xcframework"
+  s.xcconfig = { 'HEADER_SEARCH_PATHS' => "${PODS_XCFRAMEWORKS_BUILD_DIR}/ios/EthersRS.xcframework/Headers/**" }
 
 end

--- a/ethers-ffi/ethers-rs-mobile/EthersRS.podspec
+++ b/ethers-ffi/ethers-rs-mobile/EthersRS.podspec
@@ -15,10 +15,10 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => "9.0", :tvos => "11.0" }
   s.source       = { :git => "https://github.com/uniswap/ethers-rs-mobile.git", :tag => "#{s.version}" }
 
-  s.source_files = "ios/*.h"
-  s.public_header_files = "ios/*.h"
-  s.preserve_paths = "ios/*.h"
-  s.vendored_libraries = "ios/libethers_ffi.a"
+  s.public_header_files = "libethers_ffi.xcframework/ios-arm64/Headers"
+  s.source_files = 'libethers_ffi.xcframework/ios-arm64/Headers'
+  s.preserve_paths =  'ios/libethers_ffi.xcframework/*'
+  s.vendored_frameworks = "ios/libethers_ffi.xcframework"
   s.xcconfig = { 'HEADER_SEARCH_PATHS' => "${PODS_ROOT}/#{s.name}/ios/**" }
 
 end

--- a/ethers-ffi/ethers-rs-mobile/package.json
+++ b/ethers-ffi/ethers-rs-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/ethers-rs-mobile",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "MIT",
   "description": "ethers-rs for mobile"
 }

--- a/ethers-ffi/module.modulemap
+++ b/ethers-ffi/module.modulemap
@@ -1,0 +1,4 @@
+module EthersRS {
+    umbrella header "Headers/libethers_ffi.h"
+    export *
+}


### PR DESCRIPTION
## Motivation

The only supported iOS architectures used to be `x86_64-apple-ios` and `aarch64-apple-ios`, so this couldn't run on arm64 simulators (`aarch64-apple-ios-sim`).
In order to add support for `aarch64-apple-ios-sim`, we can't just `lipo` the binaries together because `aarch64-apple-ios` and `aarch64-apple-ios-sim` are both arm64. So we need to build an xcframework.

## Solution

Build one binary for `iphoneos` and one binary for `iphonesimulator`, and bundle them into an `xcframework`.

## PR Checklist

Tested by running `make ios` and placing the contents of the `ios` folder and `EthersRS.podspec` into the `node_modules` of `wallet-internal` which already depends on `v0.0.3` of this library. Then, deleting the `Pods` folder and running `pod install` which sources from the `node_modules` folder. I believe this simulates fetching the updated contents into `node_modules`, but let me know if there's a better way to test.
Before:
<img width="712" alt="image" src="https://github.com/Uniswap/ethers-rs-mobile/assets/1976718/5130f630-22fd-4686-a3d3-ebfdb1d5187e">
After (`EthersRS.podspec` also overwritten):
<img width="725" alt="image" src="https://github.com/Uniswap/ethers-rs-mobile/assets/1976718/c6dc5300-3cfa-44b7-a033-69de551855ef">
