### PR TITLE
fix: derivation input type

### DIFF
--- a/ethers-ffi/ethers-rs-mobile/package.json
+++ b/ethers-ffi/ethers-rs-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/ethers-rs-mobile",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "MIT",
   "description": "ethers-rs for mobile"
 }

--- a/ethers-ffi/src/lib.rs
+++ b/ethers-ffi/src/lib.rs
@@ -298,7 +298,7 @@ pub mod android {
     use super::*;
     use self::jni::JNIEnv;
     use self::jni::objects::{JClass, JString, JValue, JObject};
-    use self::jni::sys::{jlong, jobject, jstring, jboolean};
+    use self::jni::sys::{jlong, jobject, jstring, jboolean, jint};
 
     fn rust_string_to_jstring<'a>(env: &'a JNIEnv, rust_string: String) -> JString<'a> {
         env.new_string(rust_string).expect("Failed to create Java string")
@@ -382,7 +382,7 @@ pub mod android {
     }
 
     #[no_mangle]
-    pub extern "system" fn Java_com_uniswap_EthersRs_privateKeyFromMnemonic(env: JNIEnv, _class: JClass, mnemonic: JString, index: jlong) -> jobject {
+    pub extern "system" fn Java_com_uniswap_EthersRs_privateKeyFromMnemonic(env: JNIEnv, _class: JClass, mnemonic: JString, index: jint) -> jobject {
 
         let mnemonic_string = jstring_to_rust_string(&env, mnemonic);
         let private_key_struct = private_key_from_mnemonic_rust(mnemonic_string, index as u32);

--- a/ethers-ffi/src/lib.rs
+++ b/ethers-ffi/src/lib.rs
@@ -384,6 +384,11 @@ pub mod android {
     #[no_mangle]
     pub extern "system" fn Java_com_uniswap_EthersRs_privateKeyFromMnemonic(env: JNIEnv, _class: JClass, mnemonic: JString, index: jint) -> jobject {
 
+        // jint is i32 so check before casting to u32
+        if (index < 0) {
+            panic!("Derivation index must be greater than or equal to 0");
+        }
+
         let mnemonic_string = jstring_to_rust_string(&env, mnemonic);
         let private_key_struct = private_key_from_mnemonic_rust(mnemonic_string, index as u32);
 


### PR DESCRIPTION
The type for the `Java_com_uniswap_EthersRs_privateKeyFromMnemonic` JNI header's `derivationIndex` was `jlong` instead of `jint` as it is on the Kotlin function definition. This was usually fine, but causing issues with returning the proper address on lower-end Android devices. 