### PR TITLE
feat: update page size alignment

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,13 @@
+# Android 16KB page size support (required for Google Play, Android 15+)
+# All LOAD segments in the .so must be aligned to 16KB (2^14)
+[target.aarch64-linux-android]
+rustflags = ["-Clink-arg=-z", "-Clink-arg=max-page-size=16384"]
+
+[target.armv7-linux-androideabi]
+rustflags = ["-Clink-arg=-z", "-Clink-arg=max-page-size=16384"]
+
+[target.i686-linux-android]
+rustflags = ["-Clink-arg=-z", "-Clink-arg=max-page-size=16384"]
+
+[target.x86_64-linux-android]
+rustflags = ["-Clink-arg=-z", "-Clink-arg=max-page-size=16384"]

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 /.envrc
 .idea
+*.so

--- a/README.md
+++ b/README.md
@@ -100,6 +100,37 @@ in the transactions which are fetched over JSON-RPC.
 - [ ] FFI Bindings (see note)
 - [ ] CLI for common operations
 
+## Uniswap Mobile Integration
+
+This is a Uniswap fork of ethers-rs used to build native FFI binaries for the Uniswap mobile app. Changes to this repo should be extremely infrequent — we expect to migrate away from this package before any further changes are needed.
+
+### How it works
+
+The `ethers-ffi` crate compiles to native `.so` (Android) and `.a`/`.xcframework` (iOS) binaries. The pre-built Android `.so` files are checked into this repo under `ethers-ffi/ethers-rs-mobile/android/jniLibs/`. **npm is not used** — the binaries are manually copied to the [universe](https://github.com/Uniswap/universe) monorepo.
+
+### Making changes
+
+If you need to update the native binaries:
+
+1. Make your code or config changes in this repo
+2. Build the Android `.so` files:
+   ```sh
+   cd ethers-ffi
+   make android
+   ```
+   This requires Android NDK 25.2 installed at `~/Library/Android/sdk/ndk/25.2.9519653/`.
+3. Verify 16KB page alignment (required for Android 15+):
+   ```sh
+   ./scripts/verify-android-alignment.sh
+   ```
+4. Commit the updated `.so` files to this repo
+5. Copy the `.so` files from `ethers-ffi/ethers-rs-mobile/android/jniLibs/` to the corresponding location in the universe monorepo
+6. For iOS, build and copy the `.xcframework` similarly (`make ios` from `ethers-ffi/`)
+
+### Android 16KB page size
+
+Google Play requires all apps targeting Android 15+ to support 16KB memory page sizes (enforced May 2026). The `.cargo/config.toml` at the workspace root passes `-z max-page-size=16384` to the linker for all Android targets. This config is intentionally at the workspace root (not inside `ethers-ffi/`) because Cargo's [hierarchical config resolution](https://doc.rust-lang.org/cargo/reference/config.html) walks up parent directories — placing it at the root ensures the flags apply regardless of whether you build from the workspace root or from `ethers-ffi/`.
+
 ## Note on WASM and FFI bindings
 
 You should be able to build a wasm app that uses ethers-rs (see the [example](./examples/ethers-wasm) for reference). If ethers fails to

--- a/ethers-ffi/ethers-rs-mobile/package.json
+++ b/ethers-ffi/ethers-rs-mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/ethers-rs-mobile",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "MIT",
   "description": "ethers-rs for mobile"
 }

--- a/scripts/test-cargo-config.sh
+++ b/scripts/test-cargo-config.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Tests that .cargo/config.toml correctly configures 16KB page alignment
+# for all Android targets used in the Makefile.
+# This test runs without the Android NDK or Rust cross-compilation targets.
+
+set -euo pipefail
+
+CONFIG=".cargo/config.toml"
+MAKEFILE="ethers-ffi/Makefile"
+ERRORS=0
+
+echo "=== Testing .cargo/config.toml for 16KB page alignment ==="
+
+# Test 1: config.toml exists
+if [ ! -f "$CONFIG" ]; then
+  echo "FAIL: $CONFIG does not exist"
+  exit 1
+fi
+echo "PASS: $CONFIG exists"
+
+# Test 2: All Android targets from Makefile are covered
+MAKEFILE_TARGETS=$(grep "^ARCHS_ANDROID" "$MAKEFILE" | sed 's/^[^=]*=\s*//' | tr ' ' '\n' | grep -v '^$' | sort)
+CONFIG_TARGETS=$(grep '^\[target\.' "$CONFIG" | sed 's/\[target\.\(.*\)\]/\1/' | sort)
+
+MISSING=""
+for target in $MAKEFILE_TARGETS; do
+  if ! echo "$CONFIG_TARGETS" | grep -qx "$target"; then
+    MISSING="$MISSING $target"
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+
+if [ -n "$MISSING" ]; then
+  echo "FAIL: Missing config for targets:$MISSING"
+else
+  echo "PASS: All Makefile Android targets have config entries"
+fi
+
+# Test 3: Each target has the correct rustflags for 16KB page size
+for target in $CONFIG_TARGETS; do
+  # Extract the rustflags line following the target section
+  section_content=$(awk "/^\[target\.$target\]/{found=1;next} /^\[/{found=0} found" "$CONFIG")
+
+  if ! echo "$section_content" | grep -q 'max-page-size=16384'; then
+    echo "FAIL: [$target] missing max-page-size=16384 in rustflags"
+    ERRORS=$((ERRORS + 1))
+  else
+    echo "PASS: [$target] has max-page-size=16384"
+  fi
+
+  # Verify the -z flag is present (linker flag format: -z max-page-size=16384)
+  if ! echo "$section_content" | grep -q '\-Clink-arg=-z'; then
+    echo "FAIL: [$target] missing -Clink-arg=-z (required for linker -z flag)"
+    ERRORS=$((ERRORS + 1))
+  else
+    echo "PASS: [$target] has -Clink-arg=-z"
+  fi
+done
+
+# Test 4: Verify the flags won't affect non-Android targets
+if grep -q '\[target\.\*\]' "$CONFIG" 2>/dev/null; then
+  echo "WARN: Wildcard target found - may affect non-Android builds"
+fi
+echo "PASS: No wildcard targets (flags only apply to Android)"
+
+echo ""
+if [ "$ERRORS" -gt 0 ]; then
+  echo "FAILED: $ERRORS test(s) failed"
+  exit 1
+fi
+echo "ALL TESTS PASSED"

--- a/scripts/verify-android-alignment.sh
+++ b/scripts/verify-android-alignment.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Verifies that all Android .so files have 16KB-aligned LOAD segments.
+# Required for Google Play Android 15+ (APPS-9315).
+#
+# Usage: ./scripts/verify-android-alignment.sh [path/to/jniLibs]
+# Defaults to ethers-ffi/ethers-rs-mobile/android/jniLibs
+
+set -euo pipefail
+
+JNILIBS_DIR="${1:-ethers-ffi/ethers-rs-mobile/android/jniLibs}"
+EXPECTED_ALIGN="2**14"
+ERRORS=0
+
+if [ ! -d "$JNILIBS_DIR" ]; then
+  echo "ERROR: Directory not found: $JNILIBS_DIR"
+  echo "Build the Android libraries first (make -C ethers-ffi android)"
+  exit 1
+fi
+
+for so_file in "$JNILIBS_DIR"/*/libethers_ffi.so; do
+  if [ ! -f "$so_file" ]; then
+    echo "WARNING: No .so files found in $JNILIBS_DIR"
+    exit 1
+  fi
+
+  arch_dir=$(basename "$(dirname "$so_file")")
+  echo "Checking $arch_dir/libethers_ffi.so..."
+
+  # Extract LOAD segment alignments
+  load_aligns=$(objdump -p "$so_file" 2>/dev/null | grep -A1 "LOAD" | grep "align" | awk '{print $NF}')
+
+  if [ -z "$load_aligns" ]; then
+    # Try llvm-objdump or readelf as fallback
+    load_aligns=$(readelf -l "$so_file" 2>/dev/null | grep "LOAD" | awk '{print $NF}' || true)
+    if [ -z "$load_aligns" ]; then
+      echo "  ERROR: Could not read ELF LOAD segments from $so_file"
+      ERRORS=$((ERRORS + 1))
+      continue
+    fi
+
+    # readelf shows alignment as hex (e.g., 0x4000 = 16384)
+    for align in $load_aligns; do
+      align_dec=$((align))
+      if [ "$align_dec" -lt 16384 ]; then
+        echo "  FAIL: LOAD segment alignment $align ($align_dec bytes) < 16384 (16KB)"
+        ERRORS=$((ERRORS + 1))
+      else
+        echo "  OK: LOAD segment alignment $align ($align_dec bytes) >= 16KB"
+      fi
+    done
+  else
+    # objdump shows alignment as 2**N
+    for align in $load_aligns; do
+      power=$(echo "$align" | sed 's/2\*\*//')
+      if [ "$power" -lt 14 ]; then
+        echo "  FAIL: LOAD segment alignment 2**$power < 2**14 (16KB)"
+        ERRORS=$((ERRORS + 1))
+      else
+        echo "  OK: LOAD segment alignment 2**$power >= 2**14 (16KB)"
+      fi
+    done
+  fi
+done
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo ""
+  echo "FAILED: $ERRORS LOAD segment(s) have alignment < 16KB"
+  echo "Ensure .cargo/config.toml sets rustflags with -Clink-arg=-z -Clink-arg=max-page-size=16384"
+  exit 1
+fi
+
+echo ""
+echo "PASSED: All Android .so files have 16KB-aligned LOAD segments"


### PR DESCRIPTION
## Motivation

Google Play requires all apps targeting Android 15+ to support 16KB memory page sizes starting **May 30, 2026** ([Android docs](https://developer.android.com/guide/practices/page-sizes)). Without this, app updates cannot be published.

The pre-built `libethers_ffi.so` files shipped by `@uniswap/ethers-rs-mobile` have ELF LOAD segments aligned to 4KB (`2**12`). They must be aligned to 16KB (`2**14`).

**Ticket:** [INFRA-1081](https://linear.app/uniswap/issue/INFRA-1081/update-app-to-support-16kb-on-android)

## Solution

Added `.cargo/config.toml` with `rustflags` that pass `-z max-page-size=16384` to the linker for all 4 Android targets:

- `aarch64-linux-android` (arm64-v8a)
- `armv7-linux-androideabi` (armeabi-v7a)
- `i686-linux-android` (x86)
- `x86_64-linux-android` (x86_64)

Cargo automatically applies these flags when building for any Android target — no Makefile changes needed. The flags have no effect on iOS, WASM, or desktop builds.

Also bumped `package.json` version from `0.0.5` → `0.0.6` and added verification scripts.

## Verification

### Build & binary verification (done locally)

Successfully compiled `libethers_ffi.so` for `aarch64-linux-android` using NDK 25.2 and verified the output:

```
$ llvm-objdump -p target/aarch64-linux-android/release/libethers_ffi.so | grep -A1 LOAD

    LOAD off    0x... vaddr 0x... paddr 0x... align 2**14
    LOAD off    0x... vaddr 0x... paddr 0x... align 2**14
    LOAD off    0x... vaddr 0x... paddr 0x... align 2**14
    LOAD off    0x... vaddr 0x... paddr 0x... align 2**14
```

All 4 LOAD segments show `align 2**14` (16KB) — confirmed the linker flags are applied correctly.

We also confirmed the flags appear in the actual linker invocation output:
```
... "-z" "max-page-size=16384"
```

### Config validation test

Added `scripts/test-cargo-config.sh` which validates:
- `.cargo/config.toml` exists
- All Android targets from the Makefile are covered
- Each target has the correct `max-page-size=16384` and `-Clink-arg=-z` flags
- No wildcard targets that could affect non-Android builds

```
$ ./scripts/test-cargo-config.sh
PASS: .cargo/config.toml exists
PASS: All Makefile Android targets have config entries
PASS: [aarch64-linux-android] has max-page-size=16384
PASS: [aarch64-linux-android] has -Clink-arg=-z
PASS: [armv7-linux-androideabi] has max-page-size=16384
PASS: [armv7-linux-androideabi] has -Clink-arg=-z
PASS: [i686-linux-android] has max-page-size=16384
PASS: [i686-linux-android] has -Clink-arg=-z
PASS: [x86_64-linux-android] has max-page-size=16384
PASS: [x86_64-linux-android] has -Clink-arg=-z
PASS: No wildcard targets (flags only apply to Android)
ALL TESTS PASSED
```

### Post-build alignment verification script

Added `scripts/verify-android-alignment.sh` for verifying the actual `.so` files after a full build (all 4 architectures). Uses `objdump`/`readelf` to inspect ELF LOAD segment alignment.

## Risk Assessment

| Factor | Rating | Notes |
|--------|--------|-------|
| Code change complexity | Low | Linker flag addition only, zero code changes |
| Backward compatibility | None | 16KB-aligned binaries work on both 4KB and 16KB page-size devices |
| Blast radius | Low | Only affects Android `.so` linking; iOS/WASM/desktop unaffected |
| Binary size | Negligible | Slight increase from alignment padding |

## Remaining steps after merge

1. Rebuild all 4 `.so` variants (`make -C ethers-ffi android`)
2. Run `./scripts/verify-android-alignment.sh` to confirm
3. Publish `@uniswap/ethers-rs-mobile@0.0.6` to npm
4. Bump dependency in universe monorepo (`apps/mobile/package.json`)
5. Validate on a 16KB page-size Android 15 emulator